### PR TITLE
Determine storepath with UserDefaults

### DIFF
--- a/migrator/AppContext.swift
+++ b/migrator/AppContext.swift
@@ -70,6 +70,9 @@ struct AppContext {
     /// UserDefaults key indicating which policy to use fo handle duplicate files on the destination device.
     private static let duplicateFilesHandlingPolicyKey: String = "duplicateFilesHandlingPolicy"
 
+    /// UserDefaults key indicating the list of paths to exclude during file discovery
+    private static let excludedPathsListKey: String = "excludedPathsList"
+
     /// UserDefaults key indicating whether the app should skip the device reboot step after migration.
     static let skipRebootUserDefaultsKey: String = "skipDeviceReboot"
     
@@ -105,11 +108,16 @@ struct AppContext {
     static var duplicateFilesHandlingPolice: DuplicateFilesHandlingPolicy {
         return DuplicateFilesHandlingPolicy(rawValue: UserDefaults.standard.string(forKey: Self.duplicateFilesHandlingPolicyKey) ?? "overwrite") ?? .overwrite
     }
-    
+    static var urlExclusionsList: [URL?] {
+        let managedExcludedPaths = UserDefaults.standard.array(forKey: Self.excludedPathsListKey) as? [String] ?? []
+        let managedExcludedURLs = managedExcludedPaths.compactMap { URL(string: $0) }
+        return managedExcludedURLs + defaultUrlExclusionList
+    }
+
     // MARK: - File Scan Variables
-    
-    /// Custom list of paths tha needs to be ignored during file discovery.
-    static var urlExclusionList: [URL?] = [FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first,
+
+    /// Custom list of paths that needs to be ignored during file discovery.
+    static var defaultUrlExclusionList: [URL?] = [FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first,
                                            FileManager.default.urls(for: .applicationDirectory, in: .localDomainMask).first?.appendingPathComponent("\(Bundle.main.name).app"),
                                            FileManager.default.urls(for: .applicationDirectory, in: .localDomainMask).first?.appendingPathComponent("Numbers.app"),
                                            FileManager.default.urls(for: .applicationDirectory, in: .localDomainMask).first?.appendingPathComponent("Pages.app"),

--- a/migrator/AppContext.swift
+++ b/migrator/AppContext.swift
@@ -108,7 +108,7 @@ struct AppContext {
     static var duplicateFilesHandlingPolice: DuplicateFilesHandlingPolicy {
         return DuplicateFilesHandlingPolicy(rawValue: UserDefaults.standard.string(forKey: Self.duplicateFilesHandlingPolicyKey) ?? "overwrite") ?? .overwrite
     }
-    static var urlExclusionsList: [URL?] {
+    static var urlExclusionList: [URL?] {
         let managedExcludedPaths = UserDefaults.standard.array(forKey: Self.excludedPathsListKey) as? [String] ?? []
         let managedExcludedURLs = managedExcludedPaths.compactMap { URL(string: $0) }
         return managedExcludedURLs + defaultUrlExclusionList

--- a/migrator/AppContext.swift
+++ b/migrator/AppContext.swift
@@ -37,7 +37,15 @@ struct AppContext {
     ]
 
     /// Path the Jamf Self Service .app
-    static let storePath: String = "/Applications/Company Self Service.app"
+    static let fallbackStorePath: String = "/Applications/Company Self Service.app"
+
+    /// Returns the path to the Jamf Self Service .app configured on the user's device OR the fallbackStorePath
+    /// Reads the plist at /Library/Preferences/com.jamfsoftware.jamf.plist to get the path.
+    static var storePath: String {
+        let jamfUserDefaults = UserDefaults(suiteName: "com.jamfsoftware.jamf")
+        let jamfSelfServicePath = jamfUserDefaults?.string(forKey: "self_service_app_path")
+        return jamfSelfServicePath ?? fallbackStorePath
+    }
 
     /// A URL to redirect users to setup instructions if the app detects the device is not managed by MDM.
     static let enrollmentRedirectionLink: String = "https://url.to.enrollment/support.website"


### PR DESCRIPTION
This PR determines the Jamf Self Service app path (`storePath`) property via `UserDefaults(suiteName: String)`. As a fallback, you can hard-code `fallbackStorePath` with the path to Jamf's Self Service app if you'd like.

This will resolve #13 

## Pre-launch Checklist

- [X] I read the [Code of Conduct](/CODE_OF_CONDUCT.md) and followed the process outlined there for submitting PRs.
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I updated [README.md](https://github.com/IBM/mac-ibm-migration-tool/blob/main/README.md) file with new version/info - if applicable.
- [NA] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [NA ] All existing and new tests are passing.
