### PR TITLE
Make mdm environments managed

### DIFF
--- a/migrator/Model/DeviceManagement/ManagedEnvironment.swift
+++ b/migrator/Model/DeviceManagement/ManagedEnvironment.swift
@@ -17,4 +17,23 @@ struct ManagedEnvironment {
     var name: String
     var serverURL: String
     var reconPolicyID: String
+
+    // MARK: - Initializers
+
+    init(name: String, serverURL: String, reconPolicyID: String) {
+        self.name = name
+        self.reconPolicyID = reconPolicyID
+
+        /// Allow for serverURL to be input without the "/mdm/ServerURL" suffix.
+        if !serverURL.hasSuffix("/mdm/ServerURL") {
+            if serverURL.hasSuffix("/") {
+                self.serverURL = serverURL + "mdm/ServerURL"
+            } else {
+                self.serverURL = serverURL + "/mdm/ServerURL"
+            }
+        } else {
+            /// The serverURL is already formatted correctly.
+            self.serverURL = serverURL
+        }
+    }
 }


### PR DESCRIPTION
This PR does two things:

1. Allows you to configure the `mdmEnvironment: [ManagedEnvironment]` object using a profile. This will allow an admin to get the app up and running with little work.
2. Allows you to define `serverURL` property in `ManagedEnvironment` object with OR without the `/mdm/ServerURL` suffix. I think this will help people configure the app easier and we can handle ensuring the URL is the correct format in code.

Example of the various different ways you can configure the `mdmEnvironment` key:
```xml
<key>mdmEnvironments</key>
<array>
    <dict>
        <key>name</key>
        <string>Jamf Pro Server 1</string>
        <key>serverURL</key>
        <string>https://server1.company.com</string>
        <key>reconPolicyID</key>
        <string>033</string>
    </dict>
    <dict>
        <key>name</key>
        <string>Jamf Pro Server 2 With Trailing Slash Because Copy/Paste</string>
        <key>serverURL</key>
        <string>https://server2.company.com/</string>
        <key>reconPolicyID</key>
        <string>037</string>
    </dict>
    <dict>
        <key>name</key>
        <string>Jamf Pro Server 3 With mdm/ServerURL Path</string>
        <key>serverURL</key>
        <string>https://server3.company.com/mdm/ServerURL</string>
        <key>reconPolicyID</key>
        <string>039</string>
    </dict>
</array>
```

*List which issues are fixed by this PR. You must list at least one issue.*
This resolves #15. 

## Pre-launch Checklist

- [X] I read the [Code of Conduct](/CODE_OF_CONDUCT.md) and followed the process outlined there for submitting PRs.
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I updated [README.md](https://github.com/IBM/mac-ibm-migration-tool/blob/main/README.md) file with new version/info - if applicable.
- [X] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [X] All existing and new tests are passing.
