### PR TITLE
Variable base path construction

### DIFF
--- a/migrator.xcodeproj/project.pbxproj
+++ b/migrator.xcodeproj/project.pbxproj
@@ -832,7 +832,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 121;
+				CURRENT_PROJECT_VERSION = 130;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"migrator/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -852,7 +852,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.company.migrator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -871,7 +871,7 @@
 				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
-				CURRENT_PROJECT_VERSION = 121;
+				CURRENT_PROJECT_VERSION = 130;
 				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_ASSET_PATHS = "\"migrator/Preview Content\"";
 				DEVELOPMENT_TEAM = "";
@@ -891,7 +891,7 @@
 					"@executable_path/../Frameworks",
 				);
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
-				MARKETING_VERSION = 1.2.0;
+				MARKETING_VERSION = 1.2.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.company.migrator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";

--- a/migrator/AppContext.swift
+++ b/migrator/AppContext.swift
@@ -198,13 +198,17 @@ struct AppContext {
         return policy
     }
     static var managedExcludedURLs: [URL?] {
-        return (UserDefaults.standard.array(forKey: Self.excludedPathsListKey) as? [String] ?? []).compactMap { FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent($0) }
+        return (UserDefaults.standard.array(forKey: Self.excludedPathsListKey) as? [String] ?? []).compactMap { urlString in
+            return Utils.parseProfileURL(urlString)
+        }
     }
     static var urlExclusionList: [URL?] {
         return managedExcludedURLs + defaultUrlExclusionList
     }
     static var managedAllowedURLs: [URL?] {
-        return (UserDefaults.standard.array(forKey: Self.allowedPathsListKey) as? [String] ?? []).compactMap { FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent($0) }
+        return (UserDefaults.standard.array(forKey: Self.allowedPathsListKey) as? [String] ?? []).compactMap { urlString in
+            return Utils.parseProfileURL(urlString)
+        }
     }
     static var explicitAllowList: [URL?] {
         return managedAllowedURLs + defaultExplicitAllowList

--- a/migrator/Resources/Utils.swift
+++ b/migrator/Resources/Utils.swift
@@ -154,4 +154,22 @@ struct Utils {
             window.styleMask.update(with: .closable)
         }
     }
+    
+    static func parseProfileURL(_ urlString: String) -> URL? {
+        if urlString.contains("$HOMEFOLDER") {
+            var finalUrl = urlString.replacingOccurrences(of: "$HOMEFOLDER", with: "")
+            if finalUrl.starts(with: "/") {
+                finalUrl.removeFirst()
+            }
+            return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(finalUrl)
+        }
+        if urlString.contains("$APPFOLDER") {
+            var finalUrl = urlString.replacingOccurrences(of: "$APPFOLDER", with: "")
+            if finalUrl.starts(with: "/") {
+                finalUrl.removeFirst()
+            }
+            return FileManager.default.urls(for: .applicationDirectory, in: .localDomainMask).first?.appendingPathComponent(finalUrl)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(urlString)
+    }
 }


### PR DESCRIPTION
## Change-log
* The variable base path construction for the `excludedPathsList` and `allowedPathsList` configuration profile keys has been enabled. This allows admins to define the base path of URLs they want to exclude or allow using `$HOMEFOLDER` and `$APPFOLDER`. If the tag is missing, the app will automatically consider the user’s home folder as the base path.

Closes #17 

## Pre-launch Checklist

- [x] I read the [Code of Conduct](/CODE_OF_CONDUCT.md) and followed the process outlined there for submitting PRs.
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I updated [README.md](https://github.com/IBM/mac-ibm-migration-tool/blob/main/README.md) file with new version/info - if applicable.
- [ ] I added new tests to check the change I am making or feature I am adding, or Hixie said the PR is test-exempt.
- [ ] All existing and new tests are passing.
